### PR TITLE
Enable Usage of Both Vehicles

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -1364,7 +1364,7 @@ namespace airlib
                 sensors["imu"] = createSensorSetting(SensorBase::SensorType::Imu, "imu", true);
                 //sensors["magnetometer"] = createSensorSetting(SensorBase::SensorType::Magnetometer, "magnetometer", true);
                 sensors["gps"] = createSensorSetting(SensorBase::SensorType::Gps, "gps", true);
-                sensors["barometer"] = createSensorSetting(SensorBase::SensorType::Barometer, "barometer", true);
+                //sensors["barometer"] = createSensorSetting(SensorBase::SensorType::Barometer, "barometer", true);
             }
             if (simmode_name == kSimModeTypeCar || simmode_name == kSimModeTypeBoth) {
                 sensors["gps"] = createSensorSetting(SensorBase::SensorType::Gps, "gps", true);

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -41,6 +41,7 @@ namespace airlib
 
         static constexpr char const* kSimModeTypeMultirotor = "Multirotor";
         static constexpr char const* kSimModeTypeCar = "Car";
+        static constexpr char const* kSimModeTypeBoth = "Both";
         static constexpr char const* kSimModeTypeComputerVision = "ComputerVision";
 
         struct SubwindowSetting
@@ -598,7 +599,7 @@ namespace airlib
 
             physics_engine_name = settings_json.getString("PhysicsEngineName", "");
             if (physics_engine_name == "") {
-                if (simmode_name == kSimModeTypeMultirotor)
+                if (simmode_name == kSimModeTypeMultirotor || simmode_name == kSimModeTypeBoth)
                     physics_engine_name = "FastPhysicsEngine";
                 else
                     physics_engine_name = "PhysX"; //this value is only informational for now
@@ -861,7 +862,7 @@ namespace airlib
 
             //NOTE: Do not set defaults for vehicle type here. If you do then make sure
             //to sync code in createVehicleSetting() as well.
-            if (simmode_name == kSimModeTypeMultirotor) {
+            if (simmode_name == kSimModeTypeMultirotor || simmode_name == kSimModeTypeBoth) {
                 // create simple flight as default multirotor
                 auto simple_flight_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting("SimpleFlight",
                                                                                                 kVehicleTypeSimpleFlight));
@@ -1226,7 +1227,7 @@ namespace airlib
             }
 
             if (std::isnan(camera_director.follow_distance)) {
-                if (simmode_name == kSimModeTypeCar)
+                if (simmode_name == kSimModeTypeCar || simmode_name == kSimModeTypeBoth)
                     camera_director.follow_distance = -8;
                 else
                     camera_director.follow_distance = -3;
@@ -1236,7 +1237,7 @@ namespace airlib
             if (std::isnan(camera_director.position.y()))
                 camera_director.position.y() = 0;
             if (std::isnan(camera_director.position.z())) {
-                if (simmode_name == kSimModeTypeCar)
+                if (simmode_name == kSimModeTypeCar || simmode_name == kSimModeTypeBoth)
                     camera_director.position.z() = -4;
                 else
                     camera_director.position.z() = -2;
@@ -1252,7 +1253,7 @@ namespace airlib
                 clock_type = "ScalableClock";
 
                 //override if multirotor simmode with simple_flight
-                if (simmode_name == kSimModeTypeMultirotor) {
+                if (simmode_name == kSimModeTypeMultirotor || simmode_name == kSimModeTypeBoth) {
                     //TODO: this won't work if simple_flight and PX4 is combined together!
 
                     //for multirotors we select steppable fixed interval clock unless we have
@@ -1359,17 +1360,14 @@ namespace airlib
         static void createDefaultSensorSettings(const std::string& simmode_name,
                                                 std::map<std::string, std::shared_ptr<SensorSetting>>& sensors)
         {
-            if (simmode_name == kSimModeTypeMultirotor) {
+            if (simmode_name == kSimModeTypeMultirotor || simmode_name == kSimModeTypeBoth) {
                 sensors["imu"] = createSensorSetting(SensorBase::SensorType::Imu, "imu", true);
                 sensors["magnetometer"] = createSensorSetting(SensorBase::SensorType::Magnetometer, "magnetometer", true);
                 sensors["gps"] = createSensorSetting(SensorBase::SensorType::Gps, "gps", true);
                 sensors["barometer"] = createSensorSetting(SensorBase::SensorType::Barometer, "barometer", true);
             }
-            else if (simmode_name == kSimModeTypeCar) {
+            if (simmode_name == kSimModeTypeCar || simmode_name == kSimModeTypeBoth) {
                 sensors["gps"] = createSensorSetting(SensorBase::SensorType::Gps, "gps", true);
-            }
-            else {
-                // no sensors added for other modes
             }
         }
 

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -1362,7 +1362,7 @@ namespace airlib
         {
             if (simmode_name == kSimModeTypeMultirotor || simmode_name == kSimModeTypeBoth) {
                 sensors["imu"] = createSensorSetting(SensorBase::SensorType::Imu, "imu", true);
-                sensors["magnetometer"] = createSensorSetting(SensorBase::SensorType::Magnetometer, "magnetometer", true);
+                //sensors["magnetometer"] = createSensorSetting(SensorBase::SensorType::Magnetometer, "magnetometer", true);
                 sensors["gps"] = createSensorSetting(SensorBase::SensorType::Gps, "gps", true);
                 sensors["barometer"] = createSensorSetting(SensorBase::SensorType::Barometer, "barometer", true);
             }

--- a/PythonClient/both/multi_agent_drone_car.py
+++ b/PythonClient/both/multi_agent_drone_car.py
@@ -1,0 +1,101 @@
+import setup_path
+import airsim
+
+import time
+import numpy as np
+import os
+import tempfile
+import pprint
+
+# Use below in settings.json with Blocks environment
+"""
+{
+    "SettingsVersion": 1.2,
+    "SimMode": "Both",
+    "Vehicles": {
+        "Car1": {
+          "VehicleType": "PhysXCar",
+          "X": 0, "Y": 0, "Z": -2
+        },
+        "Drone1": {
+          "VehicleType": "SimpleFlight",
+          "X": 0, "Y": 0, "Z": -5,
+      "Yaw": 90
+        }
+  }
+}
+"""
+
+# connect to the AirSim simulator
+client_1 = airsim.MultirotorClient(port=41451)
+client_1.confirmConnection()
+client_1.enableApiControl(True, "Drone1")
+client_1.armDisarm(True, "Drone1")
+
+client_2 = airsim.CarClient(port=41452)
+client_2.confirmConnection()
+client_2.enableApiControl(True, "Car1")
+car_controls1 = airsim.CarControls()
+
+f1 = client_1.takeoffAsync(vehicle_name="Drone1")
+car_state1 = client_2.getCarState("Car1")
+print("Car1: Speed %d, Gear %d" % (car_state1.speed, car_state1.gear))
+f1.join()
+state1 = client_1.getMultirotorState(vehicle_name="Drone1")
+s = pprint.pformat(state1)
+print("Drone1: State: %s" % s)
+
+f1 = client_1.moveToPositionAsync(-5, 5, -10, 5, vehicle_name="Drone1")
+car_controls1.throttle = 0.5
+car_controls1.steering = 0.5
+client_2.setCarControls(car_controls1, "Car1")
+print("Car1: Go Forward")
+f1.join()
+
+time.sleep(2)
+airsim.wait_key('Press any key to take images')
+# get camera images from the car
+responses1 = client_1.simGetImages([
+    airsim.ImageRequest("0", airsim.ImageType.DepthVis),  #depth visualization image
+    airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], vehicle_name="Drone1")  #scene vision image in uncompressed RGBA array
+print('Drone1: Retrieved images: %d' % len(responses1))
+responses2 = client_2.simGetImages([
+	airsim.ImageRequest("0", airsim.ImageType.Segmentation),  #depth visualization image
+	airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], "Car1")  #scene vision image in uncompressed RGBA array
+print('Car1: Retrieved images: %d' % (len(responses2)))
+
+
+tmp_dir = os.path.join(tempfile.gettempdir(), "airsim_drone")
+print ("Saving images to %s" % tmp_dir)
+try:
+    os.makedirs(tmp_dir)
+except OSError:
+    if not os.path.isdir(tmp_dir):
+        raise
+
+for idx, response in enumerate(responses1 + responses2):
+    filename = os.path.join(tmp_dir, str(idx))
+
+    if response.pixels_as_float:
+        print("Type %d, size %d" % (response.image_type, len(response.image_data_float)))
+        airsim.write_pfm(os.path.normpath(filename + '.pfm'), airsim.get_pfm_array(response))
+    elif response.compress: #png format
+        print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
+        airsim.write_file(os.path.normpath(filename + '.png'), response.image_data_uint8)
+    else: #uncompressed array
+        print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
+        img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
+        img_rgba = img1d.reshape(response.height, response.width, 4) #reshape array to 4 channel image array H X W X 4
+        img_rgba = np.flipud(img_rgba) #original image is flipped vertically
+        img_rgba[:,:,1:2] = 100 #just for fun add little bit of green in all pixels
+        airsim.write_png(os.path.normpath(filename + '.greener.png'), img_rgba) #write to png
+
+airsim.wait_key('Press any key to reset to original state')
+
+client_1.armDisarm(False, "Drone1")
+client_1.reset()
+client_2.reset()
+
+# that's enough fun for now. let's quit cleanly
+client_1.enableApiControl(False, "Drone1")
+client_2.enableApiControl(False, "Car1")

--- a/PythonClient/both/setup_path.py
+++ b/PythonClient/both/setup_path.py
@@ -1,0 +1,52 @@
+# Import this module to automatically setup path to local airsim module
+# This module first tries to see if airsim module is installed via pip
+# If it does then we don't do anything else
+# Else we look up grand-parent folder to see if it has airsim folder
+#    and if it does then we add that in sys.path
+
+import os,sys,inspect,logging
+
+#this class simply tries to see if airsim 
+class SetupPath:
+    @staticmethod
+    def getDirLevels(path):
+        path_norm = os.path.normpath(path)
+        return len(path_norm.split(os.sep))
+
+    @staticmethod
+    def getCurrentPath():
+        cur_filepath = os.path.abspath(inspect.getfile(inspect.currentframe()))
+        return os.path.dirname(cur_filepath)
+
+    @staticmethod
+    def getGrandParentDir():
+        cur_path = SetupPath.getCurrentPath()
+        if SetupPath.getDirLevels(cur_path) >= 2:
+            return os.path.dirname(os.path.dirname(cur_path))
+        return ''
+
+    @staticmethod
+    def getParentDir():
+        cur_path = SetupPath.getCurrentPath()
+        if SetupPath.getDirLevels(cur_path) >= 1:
+            return os.path.dirname(cur_path)
+        return ''
+
+    @staticmethod
+    def addAirSimModulePath():
+        # if airsim module is installed then don't do anything else
+        #import pkgutil
+        #airsim_loader = pkgutil.find_loader('airsim')
+        #if airsim_loader is not None:
+        #    return
+
+        parent = SetupPath.getParentDir()
+        if parent !=  '':
+            airsim_path = os.path.join(parent, 'airsim')
+            client_path = os.path.join(airsim_path, 'client.py')
+            if os.path.exists(client_path):
+                sys.path.insert(0, parent)
+        else:
+            logging.warning("airsim module not found in parent folder. Using installed package (pip install airsim).")
+
+SetupPath.addAirSimModulePath()

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -284,7 +284,7 @@ void ASimHUD::createSimMode()
                                                              FRotator::ZeroRotator,
                                                              simmode_spawn_params);
     else if (simmode_name == AirSimSettings::kSimModeTypeBoth)
-        simmode_ = this->GetWorld()->SpawnActor<ASimModeCar>(FVector::ZeroVector,
+        simmode_ = this->GetWorld()->SpawnActor<ASimModeWorldBoth>(FVector::ZeroVector,
                                                              FRotator::ZeroRotator,
                                                              simmode_spawn_params);
     else if (simmode_name == AirSimSettings::kSimModeTypeComputerVision)

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -4,6 +4,7 @@
 #include "Misc/FileHelper.h"
 
 #include "Vehicles/Multirotor/SimModeWorldMultiRotor.h"
+#include "Vehicles/Multirotor/SimModeWorldBoth.h"
 #include "Vehicles/Car/SimModeCar.h"
 #include "Vehicles/ComputerVision/SimModeComputerVision.h"
 
@@ -246,9 +247,16 @@ std::vector<ASimHUD::AirSimSettings::SubwindowSetting>& ASimHUD::getSubWindowSet
 std::string ASimHUD::getSimModeFromUser()
 {
     if (EAppReturnType::No == UAirBlueprintLib::ShowMessage(EAppMsgType::YesNo,
-                                                            "Would you like to use car simulation? Choose no to use quadrotor simulation.",
+                                                            "Would you like to use only car simulation? Choose no to use quadrotor/both simulation.",
                                                             "Choose Vehicle")) {
-        return AirSimSettings::kSimModeTypeMultirotor;
+        if (EAppReturnType::No == UAirBlueprintLib::ShowMessage(EAppMsgType::YesNo,
+            "Would you like to simulate both quadrotor and car? Choose no to use both simulation.",
+            "Choose Vehicle"))
+        {
+            return AirSimSettings::kSimModeTypeMultirotor;
+        }
+        else
+            return AirSimSettings::kSimModeTypeBoth;
     }
     else
         return AirSimSettings::kSimModeTypeCar;
@@ -272,6 +280,10 @@ void ASimHUD::createSimMode()
                                                                          FRotator::ZeroRotator,
                                                                          simmode_spawn_params);
     else if (simmode_name == AirSimSettings::kSimModeTypeCar)
+        simmode_ = this->GetWorld()->SpawnActor<ASimModeCar>(FVector::ZeroVector,
+                                                             FRotator::ZeroRotator,
+                                                             simmode_spawn_params);
+    else if (simmode_name == AirSimSettings::kSimModeTypeBoth)
         simmode_ = this->GetWorld()->SpawnActor<ASimModeCar>(FVector::ZeroVector,
                                                              FRotator::ZeroRotator,
                                                              simmode_spawn_params);

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -8,6 +8,7 @@
 #include "Misc/OutputDeviceNull.h"
 #include "Engine/World.h"
 
+#include <map>
 #include <memory>
 #include "AirBlueprintLib.h"
 #include "common/AirSimSettings.hpp"
@@ -195,7 +196,7 @@ void ASimModeBase::EndPlay(const EEndPlayReason::Type EndPlayReason)
     FRecordingThread::killRecording();
     world_sim_api_.reset();
     api_provider_.reset();
-    api_server_.reset();
+    api_servers_.clear();
     global_ned_transform_.reset();
 
     CameraDirector = nullptr;
@@ -312,10 +313,10 @@ void ASimModeBase::setWind(const msr::airlib::Vector3r& wind) const
     throw std::domain_error("setWind not implemented by SimMode");
 }
 
-std::unique_ptr<msr::airlib::ApiServerBase> ASimModeBase::createApiServer() const
+std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> ASimModeBase::createApiServer() const
 {
     //this will be the case when compilation with RPCLIB is disabled or simmode doesn't support APIs
-    return nullptr;
+    return {};
 }
 
 void ASimModeBase::setupClockSpeed()
@@ -538,16 +539,25 @@ void ASimModeBase::startApiServer()
     if (getSettings().enable_rpc) {
 
 #ifdef AIRLIB_NO_RPC
-        api_server_.reset();
+        if (!api_servers_.empty())
+        {
+            for (auto& api_server : api_servers_)
+            {
+                api_server->stop();
+            }
+            api_servers_.clear();
+        }
 #else
-        api_server_ = createApiServer();
+        api_servers_ = createApiServer();
 #endif
 
-        try {
-            api_server_->start(false, spawned_actors_.Num() + 4);
-        }
-        catch (std::exception& ex) {
-            UAirBlueprintLib::LogMessageString("Cannot start RpcLib Server", ex.what(), LogDebugLevel::Failure);
+        for (auto& api_server : api_servers_){
+            try {
+                api_server->start(false, spawned_actors_.Num() + 4);
+            }
+            catch (std::exception& ex) {
+                UAirBlueprintLib::LogMessageString("Cannot start RpcLib Server", ex.what(), LogDebugLevel::Failure);
+            }
         }
     }
     else
@@ -555,14 +565,18 @@ void ASimModeBase::startApiServer()
 }
 void ASimModeBase::stopApiServer()
 {
-    if (api_server_ != nullptr) {
-        api_server_->stop();
-        api_server_.reset(nullptr);
+    if (!api_servers_.empty())
+    {
+        for (auto& api_server : api_servers_)
+        {
+            api_server->stop();
+        }
     }
+    api_servers_.clear();
 }
 bool ASimModeBase::isApiServerStarted()
 {
-    return api_server_ != nullptr;
+    return api_servers_.empty();
 }
 
 void ASimModeBase::updateDebugReport(msr::airlib::StateReporterWrapper& debug_reporter)
@@ -702,6 +716,7 @@ void ASimModeBase::setupVehiclesAndCamera()
         }
         else {
             //add vehicles from settings
+            bool fpv_flag = true;
             for (const auto& vehicle_setting_pair : getSettings().vehicles) {
                 //if vehicle is of type for derived SimMode and auto creatable
                 const auto& vehicle_setting = *vehicle_setting_pair.second;
@@ -713,6 +728,14 @@ void ASimModeBase::setupVehiclesAndCamera()
 
                     if (vehicle_setting.is_fpv_vehicle)
                         fpv_pawn = spawned_pawn;
+                        
+                    if (getSettings().simmode_name == AirSimSettings::kSimModeTypeBoth) {
+                        // if (vehicle_setting.vehicle_type == "PhysXCar" && fpv_flag){
+                        //     fpv_flag = false;
+                        //     fpv_pawn = spawned_pawn;
+                        // }
+                        addPawnToMap(spawned_pawn, vehicle_setting.vehicle_type);
+                    }
                 }
             }
         }
@@ -913,4 +936,16 @@ void ASimModeBase::drawDistanceSensorDebugPoints()
             }
         }
     }
+}
+
+void ASimModeBase::addPawnToMap(APawn* pawn, const std::string& vehicle_type) const
+{
+    pawn_to_vehichle_.insert(std::pair<APawn*, const std::string>(pawn, vehicle_type));
+}
+std::string ASimModeBase::getVehicleType(APawn* pawn) const
+{
+    std::map<APawn*, std::string>::const_iterator it = pawn_to_vehichle_.find(pawn);
+    if (it != pawn_to_vehichle_.end())
+        return it->second;
+    return nullptr;
 }

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -127,7 +127,7 @@ public:
 protected: //must overrides
     typedef msr::airlib::AirSimSettings AirSimSettings;
 
-    virtual std::unique_ptr<msr::airlib::ApiServerBase> createApiServer() const;
+    virtual std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> createApiServer() const;
     virtual void getExistingVehiclePawns(TArray<AActor*>& pawns) const;
     virtual bool isVehicleTypeSupported(const std::string& vehicle_type) const;
     virtual std::string getVehiclePawnPathName(const AirSimSettings::VehicleSetting& vehicle_setting) const;
@@ -151,6 +151,9 @@ protected: //optional overrides
     void checkVehicleReady(); //checks if vehicle is available to use
     virtual void updateDebugReport(msr::airlib::StateReporterWrapper& debug_reporter);
     virtual void initializeExternalCameras();
+
+    void addPawnToMap(APawn* pawn, const std::string& vehicle_type) const;
+    std::string getVehicleType(APawn* pawn) const;
 
 protected: //Utility methods for derived classes
     virtual const AirSimSettings& getSettings() const;
@@ -200,7 +203,7 @@ private:
     std::unique_ptr<NedTransform> global_ned_transform_;
     std::unique_ptr<msr::airlib::WorldSimApiBase> world_sim_api_;
     std::unique_ptr<msr::airlib::ApiProvider> api_provider_;
-    std::unique_ptr<msr::airlib::ApiServerBase> api_server_;
+    std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> api_servers_;
     msr::airlib::StateReporterWrapper debug_reporter_;
 
     std::vector<std::unique_ptr<msr::airlib::VehicleSimApiBase>> vehicle_sim_apis_;
@@ -213,6 +216,8 @@ private:
     bool lidar_checks_done_ = false;
     bool lidar_draw_debug_points_ = false;
     static ASimModeBase* SIMMODE;
+
+    mutable std::map<APawn*, std::string> pawn_to_vehichle_;
 
 private:
     void setStencilIDs();

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
@@ -78,13 +78,16 @@ void ASimModeCar::Tick(float DeltaSeconds)
 
 //-------------------------------- overrides -----------------------------------------------//
 
-std::unique_ptr<msr::airlib::ApiServerBase> ASimModeCar::createApiServer() const
+std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> ASimModeCar::createApiServer() const
 {
+    std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> api_servers;
 #ifdef AIRLIB_NO_RPC
-    return ASimModeBase::createApiServer();
+    api_servers.push_back(ASimModeBase::createApiServer());
+    return api_servers;
 #else
-    return std::unique_ptr<msr::airlib::ApiServerBase>(new msr::airlib::CarRpcLibServer(
-        getApiProvider(), getSettings().api_server_address, getSettings().api_port));
+    api_servers.push_back(std::unique_ptr<msr::airlib::ApiServerBase>(new msr::airlib::CarRpcLibServer(
+        getApiProvider(), getSettings().api_server_address)));
+    return api_servers;
 #endif
 }
 

--- a/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.cpp
@@ -16,13 +16,16 @@
 #include "physics/Kinematics.hpp"
 #include "api/RpcLibServerBase.hpp"
 
-std::unique_ptr<msr::airlib::ApiServerBase> ASimModeComputerVision::createApiServer() const
+std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> ASimModeComputerVision::createApiServer() const
 {
+    std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> api_servers;
 #ifdef AIRLIB_NO_RPC
-    return ASimModeBase::createApiServer();
+    api_servers.push_back(ASimModeBase::createApiServer());
+    return api_servers;
 #else
-    return std::unique_ptr<msr::airlib::ApiServerBase>(new msr::airlib::RpcLibServerBase(
-        getApiProvider(), getSettings().api_server_address, getSettings().api_port));
+    api_servers.push_back(std::unique_ptr<msr::airlib::ApiServerBase>(new msr::airlib::RpcLibServerBase(
+        getApiProvider(), getSettings().api_server_address)));
+    return api_servers;
 #endif
 }
 

--- a/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.h
@@ -18,7 +18,7 @@ private:
     typedef AComputerVisionPawn TVehiclePawn;
 
 protected:
-    virtual std::unique_ptr<msr::airlib::ApiServerBase> createApiServer() const override;
+    virtual std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> createApiServer() const override;
     virtual void getExistingVehiclePawns(TArray<AActor*>& pawns) const override;
     virtual bool isVehicleTypeSupported(const std::string& vehicle_type) const override;
     virtual std::string getVehiclePawnPathName(const AirSimSettings::VehicleSetting& vehicle_setting) const override;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldBoth.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldBoth.cpp
@@ -104,7 +104,7 @@ void ASimModeWorldBoth::getExistingVehiclePawns(TArray<AActor*>& pawns) const
     for (AActor* fpawn : FlyingPawns)
     {
         pawns.Add(fpawn);
-        if (getSettings().simmode_name == "Both"){
+        if (getSettings().simmode_name == AirSimSettings::kSimModeTypeBoth){
             APawn* vehicle_pawn = static_cast<APawn*>(fpawn);
             addPawnToMap(vehicle_pawn, AirSimSettings::kVehicleTypeSimpleFlight);
         }
@@ -115,7 +115,7 @@ void ASimModeWorldBoth::getExistingVehiclePawns(TArray<AActor*>& pawns) const
     for (AActor* cpawn : CarPawns)
     {
         pawns.Add(cpawn);
-        if (getSettings().simmode_name == "Both"){
+        if (getSettings().simmode_name == AirSimSettings::kSimModeTypeBoth){
             APawn* vehicle_pawn = static_cast<APawn*>(cpawn);
             addPawnToMap(vehicle_pawn, AirSimSettings::kVehicleTypePhysXCar);
         }

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldBoth.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldBoth.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "SimModeWorldBoth.h"
+#include "UObject/ConstructorHelpers.h"
+#include "Logging/MessageLog.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+
+#include "AirBlueprintLib.h"
+#include "vehicles/multirotor/api/MultirotorApiBase.hpp"
+#include "Vehicles/Car/CarPawnSimApi.h"
+#include "MultirotorPawnSimApi.h"
+#include "physics/PhysicsBody.hpp"
+#include "common/ClockFactory.hpp"
+#include <memory>
+#include "vehicles/car/api/CarRpcLibServer.hpp"
+#include "vehicles/multirotor/api/MultirotorRpcLibServer.hpp"
+
+
+void ASimModeWorldBoth::BeginPlay()
+{
+    Super::BeginPlay();
+
+    //let base class setup physics world
+    initializeForPlay();
+}
+
+void ASimModeWorldBoth::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    //stop physics thread before we dismantle
+    stopAsyncUpdator();
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void ASimModeWorldBoth::setupClockSpeed()
+{
+    typedef msr::airlib::ClockFactory ClockFactory;
+
+    float clock_speed = getSettings().clock_speed;
+
+    //setup clock in ClockFactory
+    std::string clock_type = getSettings().clock_type;
+
+    if (clock_type == "ScalableClock") {
+        //scalable clock returns interval same as wall clock but multiplied by a scale factor
+        ClockFactory::get(std::make_shared<msr::airlib::ScalableClock>(clock_speed == 1 ? 1 : 1 / clock_speed));
+    }
+    else if (clock_type == "SteppableClock") {
+        //steppable clock returns interval that is a constant number irrespective of wall clock
+        //we can either multiply this fixed interval by scale factor to speed up/down the clock
+        //but that would cause vehicles like quadrotors to become unstable
+        //so alternative we use here is instead to scale control loop frequency. The downside is that
+        //depending on compute power available, we will max out control loop frequency and therefore can no longer
+        //get increase in clock speed
+
+        //Approach 1: scale clock period, no longer used now due to quadrotor instability
+        //ClockFactory::get(std::make_shared<msr::airlib::SteppableClock>(
+        //static_cast<msr::airlib::TTimeDelta>(getPhysicsLoopPeriod() * 1E-9 * clock_speed)));
+
+        //Approach 2: scale control loop frequency if clock is speeded up
+        if (clock_speed >= 1) {
+            ClockFactory::get(std::make_shared<msr::airlib::SteppableClock>(
+                static_cast<msr::airlib::TTimeDelta>(getPhysicsLoopPeriod() * 1E-9))); //no clock_speed multiplier
+
+            setPhysicsLoopPeriod(getPhysicsLoopPeriod() / static_cast<long long>(clock_speed));
+        }
+        else {
+            //for slowing down, this don't generate instability
+            ClockFactory::get(std::make_shared<msr::airlib::SteppableClock>(
+                static_cast<msr::airlib::TTimeDelta>(getPhysicsLoopPeriod() * 1E-9 * clock_speed)));
+        }
+    }
+    else
+        throw std::invalid_argument(common_utils::Utils::stringf(
+            "clock_type %s is not recognized", clock_type.c_str()));
+}
+
+//-------------------------------- overrides -----------------------------------------------//
+
+std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> ASimModeWorldBoth::createApiServer() const
+{
+    std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> api_servers;
+#ifdef AIRLIB_NO_RPC
+    api_servers.push_back(ASimModeBase::createApiServer());
+    return api_servers;
+#else
+    uint16_t port_drone = 41451;
+    api_servers.push_back(std::unique_ptr<msr::airlib::ApiServerBase>(new msr::airlib::MultirotorRpcLibServer(
+        getApiProvider(), getSettings().api_server_address, port_drone)));
+
+    uint16_t port_car = 41452;
+    api_servers.push_back(std::unique_ptr<msr::airlib::ApiServerBase>(new msr::airlib::CarRpcLibServer(
+        getApiProvider(), getSettings().api_server_address, port_car)));
+    return api_servers;
+#endif
+}
+
+void ASimModeWorldBoth::getExistingVehiclePawns(TArray<AActor*>& pawns) const
+{
+    TArray<AActor*> FlyingPawns;
+    UAirBlueprintLib::FindAllActor<TFlyingPawn>(this, FlyingPawns);
+    for (AActor* fpawn : FlyingPawns)
+    {
+        pawns.Add(fpawn);
+        if (getSettings().simmode_name == "Both"){
+            APawn* vehicle_pawn = static_cast<APawn*>(fpawn);
+            addPawnToMap(vehicle_pawn, AirSimSettings::kVehicleTypeSimpleFlight);
+        }
+    }
+
+    TArray<AActor*> CarPawns;
+    UAirBlueprintLib::FindAllActor<TCarPawn>(this, CarPawns);
+    for (AActor* cpawn : CarPawns)
+    {
+        pawns.Add(cpawn);
+        if (getSettings().simmode_name == "Both"){
+            APawn* vehicle_pawn = static_cast<APawn*>(cpawn);
+            addPawnToMap(vehicle_pawn, AirSimSettings::kVehicleTypePhysXCar);
+        }
+    }
+}
+
+bool ASimModeWorldBoth::isVehicleTypeSupported(const std::string& vehicle_type) const
+{
+    return ((vehicle_type == AirSimSettings::kVehicleTypeSimpleFlight) ||
+        (vehicle_type == AirSimSettings::kVehicleTypePhysXCar) ||
+        (vehicle_type == AirSimSettings::kVehicleTypePX4) ||
+		(vehicle_type == AirSimSettings::kVehicleTypeArduCopterSolo));
+}
+std::string ASimModeWorldBoth::getVehiclePawnPathName(const AirSimSettings::VehicleSetting& vehicle_setting) const
+{
+    //decide which derived BP to use
+    std::string pawn_path = vehicle_setting.pawn_path;
+    if (pawn_path == ""){
+        if (vehicle_setting.vehicle_type == AirSimSettings::kVehicleTypePhysXCar) {
+            pawn_path = "DefaultCar";
+        } else {
+            pawn_path = "DefaultQuadrotor";
+        }
+    }
+    return pawn_path;
+}
+PawnEvents* ASimModeWorldBoth::getVehiclePawnEvents(APawn* pawn) const
+{
+    std::string vehicle_type = getVehicleType(pawn);
+    if (vehicle_type == AirSimSettings::kVehicleTypePhysXCar){
+        return static_cast<TCarPawn*>(pawn)->getPawnEvents();
+    } else {
+        return static_cast<TFlyingPawn*>(pawn)->getPawnEvents();
+    }
+}
+const common_utils::UniqueValueMap<std::string, APIPCamera*> ASimModeWorldBoth::getVehiclePawnCameras(
+    APawn* pawn) const
+{
+    std::string vehicle_type = getVehicleType(pawn);
+    if (vehicle_type == AirSimSettings::kVehicleTypePhysXCar){
+        return (static_cast<const TCarPawn*>(pawn))->getCameras();
+    } else {
+        return (static_cast<const TFlyingPawn*>(pawn))->getCameras();
+    }
+}
+void ASimModeWorldBoth::initializeVehiclePawn(APawn* pawn)
+{
+    std::string vehicle_type = getVehicleType(pawn);
+    if (vehicle_type == AirSimSettings::kVehicleTypePhysXCar){
+        static_cast<TCarPawn*>(pawn)->initializeForBeginPlay(getSettings().engine_sound);
+    } else {
+        static_cast<TFlyingPawn*>(pawn)->initializeForBeginPlay();
+    }
+}
+std::unique_ptr<PawnSimApi> ASimModeWorldBoth::createVehicleSimApi(
+    const PawnSimApi::Params& pawn_sim_api_params) const
+{
+    APawn* pawn = pawn_sim_api_params.pawn;
+    std::string vehicle_type = getVehicleType(pawn);
+    if (vehicle_type == AirSimSettings::kVehicleTypePhysXCar){
+        auto vehicle_pawn = static_cast<TCarPawn*>(pawn_sim_api_params.pawn);
+        auto vehicle_sim_api = std::unique_ptr<PawnSimApi>(new CarPawnSimApi(pawn_sim_api_params, vehicle_pawn->getKeyBoardControls()));
+        vehicle_sim_api->initialize();
+        // vehicle_sim_api->reset();
+        return vehicle_sim_api;
+    } else {
+        auto vehicle_sim_api = std::unique_ptr<PawnSimApi>(new MultirotorPawnSimApi(pawn_sim_api_params));
+        vehicle_sim_api->initialize();
+        //For multirotors the vehicle_sim_api are in PhysicsWorld container and then get reseted when world gets reseted
+        return vehicle_sim_api;
+    }
+    //vehicle_sim_api->reset();
+}
+msr::airlib::VehicleApiBase* ASimModeWorldBoth::getVehicleApi(const PawnSimApi::Params& pawn_sim_api_params,
+    const PawnSimApi* sim_api) const
+{
+    APawn* pawn = pawn_sim_api_params.pawn;
+    std::string vehicle_type = getVehicleType(pawn);
+    if (vehicle_type == AirSimSettings::kVehicleTypePhysXCar){
+        const auto car_sim_api = static_cast<const CarPawnSimApi*>(sim_api);
+        return car_sim_api->getVehicleApi();
+    } else {
+        const auto multirotor_sim_api = static_cast<const MultirotorPawnSimApi*>(sim_api);
+        return multirotor_sim_api->getVehicleApi();
+    }
+}

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldBoth.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldBoth.h
@@ -2,38 +2,25 @@
 
 #include "CoreMinimal.h"
 
-#include "SimMode/SimModeBase.h"
-#include "CarPawn.h"
+#include "Vehicles/Car/CarPawn.h"
+#include "FlyingPawn.h"
 #include "common/Common.hpp"
+#include "SimMode/SimModeWorldBase.h"
+#include "api/ApiServerBase.hpp"
 #include "api/VehicleSimApiBase.hpp"
-#include "SimModeCar.generated.h"
+#include "SimModeWorldBoth.generated.h"
+
 
 UCLASS()
-class AIRSIM_API ASimModeCar : public ASimModeBase
+class AIRSIM_API ASimModeWorldBoth : public ASimModeWorldBase
 {
     GENERATED_BODY()
 
 public:
     virtual void BeginPlay() override;
-    virtual void Tick(float DeltaSeconds) override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
-    virtual void continueForTime(double seconds) override;
-    virtual void continueForFrames(uint32_t frames) override;
-
-private:
-    typedef msr::airlib::ClockFactory ClockFactory;
-    typedef common_utils::Utils Utils;
-    typedef msr::airlib::TTimePoint TTimePoint;
-    typedef msr::airlib::TTimeDelta TTimeDelta;
-    typedef ACarPawn TVehiclePawn;
-    typedef msr::airlib::VehicleSimApiBase VehicleSimApiBase;
-    typedef msr::airlib::VectorMath VectorMath;
-    typedef msr::airlib::Vector3r Vector3r;
-
-private:
-    void initializePauseState();
-
-protected:
+protected: //overrides
     virtual void setupClockSpeed() override;
     virtual std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> createApiServer() const override;
     virtual void getExistingVehiclePawns(TArray<AActor*>& pawns) const override;
@@ -45,13 +32,9 @@ protected:
     virtual std::unique_ptr<PawnSimApi> createVehicleSimApi(
         const PawnSimApi::Params& pawn_sim_api_params) const override;
     virtual msr::airlib::VehicleApiBase* getVehicleApi(const PawnSimApi::Params& pawn_sim_api_params,
-                                                       const PawnSimApi* sim_api) const override;
+        const PawnSimApi* sim_api) const override;
 
 private:
-    std::atomic<float> current_clockspeed_;
-    std::atomic<TTimeDelta> pause_period_;
-    std::atomic<TTimePoint> pause_period_start_;
-    uint32_t targetFrameNumber_;
-    std::atomic_bool frame_countdown_enabled_;
-    ;
+    typedef ACarPawn TCarPawn;
+    typedef AFlyingPawn TFlyingPawn;
 };

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldMultiRotor.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldMultiRotor.cpp
@@ -77,13 +77,16 @@ void ASimModeWorldMultiRotor::setupClockSpeed()
 
 //-------------------------------- overrides -----------------------------------------------//
 
-std::unique_ptr<msr::airlib::ApiServerBase> ASimModeWorldMultiRotor::createApiServer() const
+std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> ASimModeWorldMultiRotor::createApiServer() const
 {
+    std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> api_servers;
 #ifdef AIRLIB_NO_RPC
-    return ASimModeBase::createApiServer();
+    api_servers.push_back(ASimModeBase::createApiServer());
+    return api_servers;
 #else
-    return std::unique_ptr<msr::airlib::ApiServerBase>(new msr::airlib::MultirotorRpcLibServer(
-        getApiProvider(), getSettings().api_server_address, getSettings().api_port));
+    api_servers.push_back(std::unique_ptr<msr::airlib::ApiServerBase>(new msr::airlib::MultirotorRpcLibServer(
+        getApiProvider(), getSettings().api_server_address)));
+    return api_servers;
 #endif
 }
 

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldMultiRotor.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldMultiRotor.h
@@ -19,7 +19,7 @@ public:
 
 protected: //overrides
     virtual void setupClockSpeed() override;
-    virtual std::unique_ptr<msr::airlib::ApiServerBase> createApiServer() const override;
+    virtual std::vector<std::unique_ptr<msr::airlib::ApiServerBase>> createApiServer() const override;
     virtual void getExistingVehiclePawns(TArray<AActor*>& pawns) const override;
     virtual bool isVehicleTypeSupported(const std::string& vehicle_type) const override;
     virtual std::string getVehiclePawnPathName(const AirSimSettings::VehicleSetting& vehicle_setting) const override;


### PR DESCRIPTION
Enable usage of both quadrotor drones and cars in the same AirSim simulation.

Heavily inspired by [this](https://idoglanz.medium.com/setting-up-microsoft-airsim-to-simulate-a-drone-and-car-together-708079b2d0f) with some changes to interface with the most recent version of AirSim